### PR TITLE
fix: ws bug

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -95,7 +95,7 @@ http {
         }
 
         location /ws/ {
-            proxy_pass http://blue-backend:8000;
+            proxy_pass http://blue-backend;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";


### PR DESCRIPTION
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
/docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
/docker-entrypoint.sh: Configuration complete; ready for start up
2025/01/22 08:15:41 [emerg] 1#1: upstream "blue-backend" may not have port 8000 in /etc/nginx/nginx.conf:98
nginx: [emerg] upstream "blue-backend" may not have port 8000 in /etc/nginx/nginx.conf:98
에 대한 버그 수정

변경된 파일
nginx.conf