### PR TITLE
fix: grafana DB 초기화 오류 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ alertmanager/alertmanager.yml
 
 secrets.json
 
+grafana

--- a/nginx.conf
+++ b/nginx.conf
@@ -129,6 +129,7 @@ http {
 
         # Django 모니터링 프록시
         location /metrics {
+            proxy_pass http://blue-backend/metrics;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
계속 Grafana DB 권한 초기화 및 대시보드등의 설정이 초기화 되길래
안되도록 수정해봤습니다.
아마 원인으로는 git에 올라온 DB정보가 계속 덮어씌어져서 그런거같아서
.gitignore에 grafana 디렉토리 추가했어요