### PR TITLE
fix: prometheus 메트릭 경로 재지정

### DIFF
--- a/Backend/settings.py
+++ b/Backend/settings.py
@@ -98,6 +98,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -106,7 +107,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'django_prometheus.middleware.PrometheusAfterMiddleware',
 ]
 

--- a/docker-compose-blue.yml
+++ b/docker-compose-blue.yml
@@ -14,6 +14,9 @@ services:
         restart: on-failure
         ports:
             - "8000:8000"
+        labels:
+            logging: "promtail" #라벨링
+            logging_jobname: "containerlogs" #그라파나에서 사용될 로그 job 이름 태그.
         environment:
             DB_NAME: "${DB_NAME}"
             DB_USER: "${DB_USER}"

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -25,9 +25,11 @@ scrape_configs:
       - targets: [ 'node_exporter:9100' ]
 
   - job_name: 'blue-backend'
-    scheme: 'http'
+    scheme: 'https'
     static_configs:
-      - targets: [ 'blue-backend:8000' ]
+      - targets: [ 'nginx:443' ]
+    tls_config:
+      insecure_skip_verify: true
 
   - job_name: 'rabbitmq'
     static_configs:


### PR DESCRIPTION
promethesu가 Django 메트릭을 수집 못하길래 수집 경로를 nginx를 통해 수집하도록 경로 수정을 했습니다.